### PR TITLE
Define fallback route for messages

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -76,7 +76,15 @@
                             ],
                             "isEnabled": true
                         }
-                    ]
+                    ],
+                    "fallbackRoute": {
+                        "name": "$fallback",
+                        "source": "DeviceMessages",
+                        "endpointNames": [
+                            "events"
+                        ],
+                        "isEnabled": true
+                    }
                 }
             },
             "dependsOn": [


### PR DESCRIPTION
Seems like without this, the messages are not routed to the built-in
events endpoint.