### PR TITLE
removes the nuget package Newtonsoft.Json

### DIFF
--- a/src/LoriotAzureFunctions/LoriotAzureFunctions.csproj
+++ b/src/LoriotAzureFunctions/LoriotAzureFunctions.csproj
@@ -5,8 +5,7 @@
   <ItemGroup>    
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.3.2" />    
     <PackageReference Include="Microsoft.Azure.WebJobs.ServiceBus" Version="2.1.0-beta1" />    
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.2" />    
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.2" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
 because is included in Microsoft.Azure.Devices and causes a version conflict.

https://docs.microsoft.com/en-us/azure/azure-functions/functions-reference-csharp
Referencing external assemblies

Resolves Issue #14 