### PR TITLE
fixing the button deployment issue

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -455,7 +455,7 @@
         {
             "name": "functionLauncher",
             "type": "Microsoft.Resources/deployments",
-            "apiVersion": "2017-05-10",
+            "apiVersion": "2014-04-01-preview",
             "dependsOn": [
                 "[resourceId('Microsoft.Web/sites/sourcecontrols', variables('functionAppName'),'web')]"    
             ],


### PR DESCRIPTION
This was  due as the deployment tool was using an old powershell version, should update in the future